### PR TITLE
Audience Range Values

### DIFF
--- a/lib/onix/audience_range.rb
+++ b/lib/onix/audience_range.rb
@@ -8,7 +8,7 @@ module ONIX
 
     xml_accessor :audience_range_qualifier, :from => "AudienceRangeQualifier", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
     xml_accessor :audience_range_precisions, :from => "AudienceRangePrecision", :as => [Fixnum], :to_xml => [ONIX::Formatters.two_digit] # TODO: two_digit isn't working on the array items
-    xml_accessor :audience_range_values, :from => "AudienceRangeValue", :as => [Integer]
+    xml_accessor :audience_range_values, :from => "AudienceRangeValue"
 
     # TODO: element AudienceRange: validity error :
     #   Element AudienceRange content does not follow the DTD, expecting


### PR DESCRIPTION
Removed the integer setting on audience_range_values as it now allows for number or string entries as per ONIX documentation.

The definition of the <AudienceRangeValue> element has been extended to allowstrings to be carried instead of integers only, so that audience ranges can bespecified in both numeric and non-numeric terms. This is particularly applicable toUS school and pre-school levels.
